### PR TITLE
Fix bug: params were initialized as None, now []

### DIFF
--- a/pyietflib/rfc6350/property.py
+++ b/pyietflib/rfc6350/property.py
@@ -67,7 +67,7 @@ class Property():
     def __init__(self, value, group=None, params=None):
         self.__value = value
         self.__group = group
-        self.__parameters = params if not None else []
+        self.__parameters = params if params is not None else []
         self.parse_value(value)
     
     def __str__(self):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 #----------------------------------------------------------------------------
 """IETF RFC media type objects."""


### PR DESCRIPTION
`params if not None else []` --- the else branch is unreachable. `params if params is not None else []` is what is wanted.

Also, bring setup.py up-to-date with the fact that this package requires python 3.
